### PR TITLE
Remove assumption that spaces are always valid separators

### DIFF
--- a/lib/term-vector.js
+++ b/lib/term-vector.js
@@ -6,6 +6,9 @@
 var sw = require('stopword');
 var _ = require('lodash');
 
+// Temporary, until proper global library is implemented to handle this.
+exports.tokenSeparator = sw.tokenSeparator;
+
 /**
 get a document vector
 @param {string} text - the text to be vectored
@@ -30,7 +33,7 @@ exports.getVector = function(text, options) {
   var tokens = sw.removeStopwords(text, {
     inputSeparator: options.separator,
     stopwords: options.stopwords
-  }).split(' ');
+  }).split(sw.tokenSeparator);
   var vec = []
   if (!isNaN(options.nGramLength)) {
     return getTermVectorForNgramLength(tokens, options.nGramLength);
@@ -65,7 +68,7 @@ var getTermVectorForNgramLength = function (tokens, nGramLength) {
   //create ngrams of desired length
   var ngrams = [];
   for (var i = 0; i <= (tokens.length - nGramLength); i++)
-    ngrams.push(tokens.slice(i, i + nGramLength).join(' '));
+    ngrams.push(tokens.slice(i, i + nGramLength).join(sw.tokenSeparator));
   //count ngrams
   ngrams = ngrams.sort();
   //special case- doc of array length 1


### PR DESCRIPTION
This corrects the assumption that spaces are always a valid token separator. Dependent upon [this pull request](https://github.com/fergiemcdowall/stopword/pull/1) in the related [stopwords](https://github.com/fergiemcdowall/stopword) module.
