### PR TITLE
fix: missing licence

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,5 +34,6 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/fergiemcdowall/term-vector.git"
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
Closes #5 

It would require a package rebuild with new version published on npmjs.org